### PR TITLE
Fix millRun goroutine leak

### DIFF
--- a/chown.go
+++ b/chown.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package lumberjack

--- a/linux_test.go
+++ b/linux_test.go
@@ -1,12 +1,13 @@
+//go:build linux
 // +build linux
 
 package lumberjack
 
 import (
 	"os"
+	"sync"
 	"syscall"
 	"testing"
-	"time"
 )
 
 func TestMaintainMode(t *testing.T) {
@@ -49,10 +50,10 @@ func TestMaintainMode(t *testing.T) {
 func TestMaintainOwner(t *testing.T) {
 	fakeFS := newFakeFS()
 	osChown = fakeFS.Chown
-	osStat = fakeFS.Stat
+	os_Stat = fakeFS.Stat
 	defer func() {
 		osChown = os.Chown
-		osStat = os.Stat
+		os_Stat = os.Stat
 	}()
 	currentTime = fakeTime
 	dir := makeTempDir("TestMaintainOwner", t)
@@ -97,11 +98,13 @@ func TestCompressMaintainMode(t *testing.T) {
 	isNil(err, t)
 	f.Close()
 
+	notify := make(chan struct{})
 	l := &Logger{
-		Compress:   true,
-		Filename:   filename,
-		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		Compress:         true,
+		Filename:         filename,
+		MaxBackups:       1,
+		MaxSize:          100, // megabytes
+		notifyCompressed: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -114,9 +117,7 @@ func TestCompressMaintainMode(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	// we need to wait a little bit since the files get compressed on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	waitForNotify(l.notifyCompressed, t)
 
 	// a compressed version of the log file should now exist with the correct
 	// mode.
@@ -132,10 +133,10 @@ func TestCompressMaintainMode(t *testing.T) {
 func TestCompressMaintainOwner(t *testing.T) {
 	fakeFS := newFakeFS()
 	osChown = fakeFS.Chown
-	osStat = fakeFS.Stat
+	os_Stat = fakeFS.Stat
 	defer func() {
 		osChown = os.Chown
-		osStat = os.Stat
+		os_Stat = os.Stat
 	}()
 	currentTime = fakeTime
 	dir := makeTempDir("TestCompressMaintainOwner", t)
@@ -147,11 +148,13 @@ func TestCompressMaintainOwner(t *testing.T) {
 	isNil(err, t)
 	f.Close()
 
+	notify := make(chan struct{})
 	l := &Logger{
-		Compress:   true,
-		Filename:   filename,
-		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		Compress:         true,
+		Filename:         filename,
+		MaxBackups:       1,
+		MaxSize:          100, // megabytes
+		notifyCompressed: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -164,15 +167,14 @@ func TestCompressMaintainOwner(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	// we need to wait a little bit since the files get compressed on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	waitForNotify(l.notifyCompressed, t)
 
 	// a compressed version of the log file should now exist with the correct
 	// owner.
 	filename2 := backupFile(dir)
-	equals(555, fakeFS.files[filename2+compressSuffix].uid, t)
-	equals(666, fakeFS.files[filename2+compressSuffix].gid, t)
+	uid, gid := fakeFS.fileOwners(filename2 + compressSuffix)
+	equals(555, uid, t)
+	equals(666, gid, t)
 }
 
 type fakeFile struct {
@@ -182,18 +184,30 @@ type fakeFile struct {
 
 type fakeFS struct {
 	files map[string]fakeFile
+	mu    sync.Mutex
 }
 
 func newFakeFS() *fakeFS {
 	return &fakeFS{files: make(map[string]fakeFile)}
 }
 
+func (fs *fakeFS) fileOwners(name string) (int, int) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	result := fs.files[name]
+	return result.uid, result.gid
+}
+
 func (fs *fakeFS) Chown(name string, uid, gid int) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	fs.files[name] = fakeFile{uid: uid, gid: gid}
 	return nil
 }
 
 func (fs *fakeFS) Stat(name string) (os.FileInfo, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
 	info, err := os.Stat(name)
 	if err != nil {
 		return nil, err

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -1,3 +1,10 @@
+// Package lumberjack provides a rolling logger.
+//
+// Note that this is v2.0 of lumberjack, and should be imported using gopkg.in
+// thusly:
+//
+//   import "gopkg.in/natefinch/lumberjack.v2"
+//
 // The package name remains simply lumberjack, and the code resides at
 // https://github.com/natefinch/lumberjack under the v2.0 branch.
 //
@@ -104,8 +111,18 @@ type Logger struct {
 	file *os.File
 	mu   sync.Mutex
 
-	millCh    chan bool
-	startMill sync.Once
+	wg     *sync.WaitGroup
+	millCh chan struct{}
+
+	// notifyCompressed is only set and used for tests. It is signalled when
+	// millRunOnce compresses some files. If no files are compressed,
+	// notifyCompressed is not signalled.
+	notifyCompressed chan struct{}
+
+	// notifyRemoved is only set and used for tests. It is signalled when the
+	// millRunOnce method removes some old log files. If no files are removed,
+	// notifyRemoved is not signalled.
+	notifyRemoved chan struct{}
 }
 
 var (
@@ -113,7 +130,7 @@ var (
 	currentTime = time.Now
 
 	// os_Stat exists so it can be mocked out by tests.
-	osStat = os.Stat
+	os_Stat = os.Stat
 
 	// megabyte is the conversion factor between MaxSize and bytes.  It is a
 	// variable so tests can mock it out and not need to write megabytes of data
@@ -158,7 +175,17 @@ func (l *Logger) Write(p []byte) (n int, err error) {
 func (l *Logger) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.close()
+	if err := l.close(); err != nil {
+		close(l.millCh)
+		return err
+	}
+	if l.millCh != nil {
+		close(l.millCh)
+		l.wg.Wait()
+		l.millCh = nil
+		l.wg = nil
+	}
+	return nil
 }
 
 // close closes the file if it is open.
@@ -206,7 +233,7 @@ func (l *Logger) openNew() error {
 
 	name := l.filename()
 	mode := os.FileMode(0600)
-	info, err := osStat(name)
+	info, err := os_Stat(name)
 	if err == nil {
 		// Copy the mode off the old logfile.
 		mode = info.Mode()
@@ -258,7 +285,7 @@ func (l *Logger) openExistingOrNew(writeLen int) error {
 	l.mill()
 
 	filename := l.filename()
-	info, err := osStat(filename)
+	info, err := os_Stat(filename)
 	if os.IsNotExist(err) {
 		return l.openNew()
 	}
@@ -347,20 +374,30 @@ func (l *Logger) millRunOnce() error {
 		}
 	}
 
+	filesRemoved := false
 	for _, f := range remove {
 		errRemove := os.Remove(filepath.Join(l.dir(), f.Name()))
 		if err == nil && errRemove != nil {
 			err = errRemove
 		}
+		filesRemoved = true
 	}
+	if filesRemoved && l.notifyRemoved != nil {
+		l.notifyRemoved <- struct{}{}
+	}
+
+	filesCompressed := false
 	for _, f := range compress {
 		fn := filepath.Join(l.dir(), f.Name())
 		errCompress := compressLogFile(fn, fn+compressSuffix)
 		if err == nil && errCompress != nil {
 			err = errCompress
 		}
+		filesCompressed = true
 	}
-
+	if filesCompressed && l.notifyCompressed != nil {
+		l.notifyCompressed <- struct{}{}
+	}
 	return err
 }
 
@@ -376,12 +413,18 @@ func (l *Logger) millRun() {
 // mill performs post-rotation compression and removal of stale log files,
 // starting the mill goroutine if necessary.
 func (l *Logger) mill() {
-	l.startMill.Do(func() {
-		l.millCh = make(chan bool, 1)
-		go l.millRun()
-	})
+	// It is safe to check the millCh here as we are inside the mutex lock.
+	if l.millCh == nil {
+		l.millCh = make(chan struct{}, 1)
+		l.wg = &sync.WaitGroup{}
+		l.wg.Add(1)
+		go func() {
+			l.millRun()
+			l.wg.Done()
+		}()
+	}
 	select {
-	case l.millCh <- true:
+	case l.millCh <- struct{}{}:
 	default:
 	}
 }
@@ -463,7 +506,7 @@ func compressLogFile(src, dst string) (err error) {
 	}
 	defer f.Close()
 
-	fi, err := osStat(src)
+	fi, err := os_Stat(src)
 	if err != nil {
 		return fmt.Errorf("failed to stat log file: %v", err)
 	}

--- a/lumberjack_test.go
+++ b/lumberjack_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,9 +25,14 @@ import (
 // Since all the tests uses the time to determine filenames etc, we need to
 // control the wall clock as much as possible, which means having a wall clock
 // that doesn't change unless we want it to.
-var fakeCurrentTime = time.Now()
+var (
+	fakeCurrentTime = time.Now()
+	fakeTimeMu      sync.Mutex
+)
 
 func fakeTime() time.Time {
+	fakeTimeMu.Lock()
+	defer fakeTimeMu.Unlock()
 	return fakeCurrentTime
 }
 
@@ -202,11 +208,13 @@ func TestMaxBackups(t *testing.T) {
 	dir := makeTempDir("TestMaxBackups", t)
 	defer os.RemoveAll(dir)
 
+	notify := make(chan struct{})
 	filename := logFile(dir)
 	l := &Logger{
-		Filename:   filename,
-		MaxSize:    10,
-		MaxBackups: 1,
+		Filename:      filename,
+		MaxSize:       10,
+		MaxBackups:    1,
+		notifyRemoved: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -248,9 +256,7 @@ func TestMaxBackups(t *testing.T) {
 
 	existsWithContent(filename, b3, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(time.Millisecond * 10)
+	waitForNotify(l.notifyCompressed, t)
 
 	// should only have two files in the dir still
 	fileCount(dir, 2, t)
@@ -298,9 +304,7 @@ func TestMaxBackups(t *testing.T) {
 	existsWithContent(fourthFilename, b3, t)
 	existsWithContent(fourthFilename+compressSuffix, []byte("compress"), t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(time.Millisecond * 10)
+	waitForNotify(l.notifyCompressed, t)
 
 	// We should have four things in the directory now - the 2 log files, the
 	// not log file, and the directory
@@ -354,24 +358,27 @@ func TestCleanupExistingBackups(t *testing.T) {
 	filename := logFile(dir)
 	err = ioutil.WriteFile(filename, data, 0644)
 	isNil(err, t)
-
+	notify := make(chan struct{})
 	l := &Logger{
-		Filename:   filename,
-		MaxSize:    10,
-		MaxBackups: 1,
+		Filename:      filename,
+		MaxSize:       10,
+		MaxBackups:    1,
+		notifyRemoved: notify,
 	}
 	defer l.Close()
 
 	newFakeTime()
 
-	b2 := []byte("foooooo!")
+	// Don't write enough to trigger a rotate or there is
+	// a race between whether or not there is one notification
+	// or two depending on how far through the millRunOnce method
+	// gets before the Write method calls rotate.
+	b2 := []byte("foo")
 	n, err := l.Write(b2)
 	isNil(err, t)
 	equals(len(b2), n, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(time.Millisecond * 10)
+	waitForNotify(l.notifyCompressed, t)
 
 	// now we should only have 2 files left - the primary and one backup
 	fileCount(dir, 2, t)
@@ -385,12 +392,15 @@ func TestMaxAge(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	filename := logFile(dir)
+	notify := make(chan struct{})
 	l := &Logger{
-		Filename: filename,
-		MaxSize:  10,
-		MaxAge:   1,
+		Filename:      filename,
+		MaxSize:       10,
+		MaxAge:        1,
+		notifyRemoved: notify,
 	}
 	defer l.Close()
+
 	b := []byte("boo!")
 	n, err := l.Write(b)
 	isNil(err, t)
@@ -407,10 +417,6 @@ func TestMaxAge(t *testing.T) {
 	isNil(err, t)
 	equals(len(b2), n, t)
 	existsWithContent(backupFile(dir), b, t)
-
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
 
 	// We should still have 2 log files, since the most recent backup was just
 	// created.
@@ -430,9 +436,7 @@ func TestMaxAge(t *testing.T) {
 	equals(len(b3), n, t)
 	existsWithContent(backupFile(dir), b2, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	waitForNotify(l.notifyCompressed, t)
 
 	// We should have 2 log files - the main log file, and the most recent
 	// backup.  The earlier backup is past the cutoff and should be gone.
@@ -539,11 +543,12 @@ func TestRotate(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	filename := logFile(dir)
-
+	notify := make(chan struct{})
 	l := &Logger{
-		Filename:   filename,
-		MaxBackups: 1,
-		MaxSize:    100, // megabytes
+		Filename:      filename,
+		MaxBackups:    1,
+		MaxSize:       100, // megabytes
+		notifyRemoved: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -559,10 +564,6 @@ func TestRotate(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
-
 	filename2 := backupFile(dir)
 	existsWithContent(filename2, b, t)
 	existsWithContent(filename, []byte{}, t)
@@ -572,9 +573,7 @@ func TestRotate(t *testing.T) {
 	err = l.Rotate()
 	isNil(err, t)
 
-	// we need to wait a little bit since the files get deleted on a different
-	// goroutine.
-	<-time.After(10 * time.Millisecond)
+	waitForNotify(l.notifyCompressed, t)
 
 	filename3 := backupFile(dir)
 	existsWithContent(filename3, []byte{}, t)
@@ -597,11 +596,13 @@ func TestCompressOnRotate(t *testing.T) {
 	dir := makeTempDir("TestCompressOnRotate", t)
 	defer os.RemoveAll(dir)
 
+	notify := make(chan struct{})
 	filename := logFile(dir)
 	l := &Logger{
-		Compress: true,
-		Filename: filename,
-		MaxSize:  10,
+		Compress:         true,
+		Filename:         filename,
+		MaxSize:          10,
+		notifyCompressed: notify,
 	}
 	defer l.Close()
 	b := []byte("boo!")
@@ -621,9 +622,7 @@ func TestCompressOnRotate(t *testing.T) {
 	// nothing in it.
 	existsWithContent(filename, []byte{}, t)
 
-	// we need to wait a little bit since the files get compressed on a different
-	// goroutine.
-	<-time.After(300 * time.Millisecond)
+	waitForNotify(l.notifyCompressed, t)
 
 	// a compressed version of the log file should now exist and the original
 	// should have been removed.
@@ -646,11 +645,13 @@ func TestCompressOnResume(t *testing.T) {
 	dir := makeTempDir("TestCompressOnResume", t)
 	defer os.RemoveAll(dir)
 
+	notify := make(chan struct{})
 	filename := logFile(dir)
 	l := &Logger{
-		Compress: true,
-		Filename: filename,
-		MaxSize:  10,
+		Compress:         true,
+		Filename:         filename,
+		MaxSize:          10,
+		notifyCompressed: notify,
 	}
 	defer l.Close()
 
@@ -670,9 +671,7 @@ func TestCompressOnResume(t *testing.T) {
 	equals(len(b2), n, t)
 	existsWithContent(filename, b2, t)
 
-	// we need to wait a little bit since the files get compressed on a different
-	// goroutine.
-	<-time.After(300 * time.Millisecond)
+	waitForNotify(l.notifyCompressed, t)
 
 	// The write should have started the compression - a compressed version of
 	// the log file should now exist and the original should have been removed.
@@ -786,12 +785,6 @@ func backupFileLocal(dir string) string {
 	return filepath.Join(dir, "foobar-"+fakeTime().Format(backupTimeFormat)+".log")
 }
 
-// logFileLocal returns the log file name in the given directory for the current
-// fake time using the local timezone.
-func logFileLocal(dir string) string {
-	return filepath.Join(dir, fakeTime().Format(backupTimeFormat))
-}
-
 // fileCount checks that the number of files in the directory is exp.
 func fileCount(dir string, exp int, t testing.TB) {
 	files, err := ioutil.ReadDir(dir)
@@ -802,6 +795,8 @@ func fileCount(dir string, exp int, t testing.TB) {
 
 // newFakeTime sets the fake "current time" to two days later.
 func newFakeTime() {
+	fakeTimeMu.Lock()
+	defer fakeTimeMu.Unlock()
 	fakeCurrentTime = fakeCurrentTime.Add(time.Hour * 24 * 2)
 }
 
@@ -813,4 +808,14 @@ func notExist(path string, t testing.TB) {
 func exists(path string, t testing.TB) {
 	_, err := os.Stat(path)
 	assertUp(err == nil, t, 1, "expected file to exist, but got error from os.Stat: %v", err)
+}
+
+func waitForNotify(notify <-chan struct{}, t testing.TB) {
+	select {
+	case <-notify:
+		// All good.
+	case <-time.After(2 * time.Second):
+		fmt.Println("logger notify not signalled")
+		t.FailNow()
+	}
 }

--- a/rotate_test.go
+++ b/rotate_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package lumberjack


### PR DESCRIPTION
This fix is from https://github.com/howbazaar/lumberjack/tree/fix-mill-once-goroutine-leak and addresses review comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/lumberjack/2)
<!-- Reviewable:end -->
